### PR TITLE
Upgrade to pnpm 11 and stabilize weather forecast rows

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-auto-install-peers=true

--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "packageManager": "pnpm@10.28.2",
+  "packageManager": "pnpm@11.13.0",
   "scripts": {
-    "start": "vite",
+    "dev": "vite",
+    "start": "pnpm run dev",
     "build": "vite build",
     "git:submodule": "git submodule update --init --recursive",
     "install:all": "pnpm run install:horizon && pnpm run install:trainboard",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  protobufjs: true

--- a/src/components/Weather.tsx
+++ b/src/components/Weather.tsx
@@ -48,22 +48,30 @@ export default function Weather() {
 			</CurrentWeather>
 			<Forecast>
 				<WeeklyForecast
-					forecasts={forecast.forecast
-						.map(
-							(day): MergedWeatherForecast => ({
+					forecasts={padForecasts(
+						forecast.forecast
+							.map((day): MergedWeatherForecast => ({
 								temperature: day.temperature,
 								templow: day.templow!,
 								condition: day.condition!,
 								datetime: new Date(day.datetime),
-							}),
-						)
-						.filter((day) => day.datetime >= startOfDay())
-						.slice(0, FORECAST_DAYS)}
+							}))
+							.filter((day) => day.datetime >= startOfDay())
+							.slice(0, FORECAST_DAYS),
+						FORECAST_DAYS,
+					)}
 					currentTemp={outdoorTemp}
 				/>
 			</Forecast>
 		</Card>
 	);
+}
+
+function padForecasts(
+	forecasts: MergedWeatherForecast[],
+	count: number,
+): (MergedWeatherForecast | null)[] {
+	return Array.from({ length: count }, (_, i) => forecasts[i] ?? null);
 }
 
 const CurrentWeather = styled.div`
@@ -98,5 +106,7 @@ const Temp = styled.span`
 const Forecast = styled.div`
 	display: flex;
 	flex-direction: column;
-	gap: 1vh;
+	justify-content: space-between;
+	flex: 1;
+	min-height: 0;
 `;

--- a/src/components/forecast/WeatherForecast.tsx
+++ b/src/components/forecast/WeatherForecast.tsx
@@ -20,12 +20,15 @@ export function WeeklyForecast({
 	currentTemp,
 	hourly = false,
 }: {
-	forecasts: MergedWeatherForecast[];
+	forecasts: (MergedWeatherForecast | null)[];
 	currentTemp: number;
 	hourly?: boolean;
 }) {
-	const minTemps = forecasts.map((f) => f.templow);
-	const maxTemps = forecasts.map((f) => f.temperature);
+	const realForecasts = forecasts.filter(
+		(forecast): forecast is MergedWeatherForecast => forecast != null,
+	);
+	const minTemps = realForecasts.map((f) => f.templow);
+	const maxTemps = realForecasts.map((f) => f.temperature);
 	minTemps.push(currentTemp);
 	maxTemps.push(currentTemp);
 	const minTemp = Math.round(min(minTemps));
@@ -33,19 +36,29 @@ export function WeeklyForecast({
 
 	const calcGradientRange = gradientRange(minTemp, maxTemp, gradientMap);
 
-	return forecasts.map((forecast) => (
-		<ForecastItem
-			key={forecast.datetime.toISOString()}
-			{...{
-				forecast,
-				gradientRange: calcGradientRange,
-				minTemp,
-				maxTemp,
-				currentTemp,
-				hourly,
-			}}
-		/>
-	));
+	return forecasts.map((forecast, index) =>
+		forecast ? (
+			<ForecastItem
+				key={forecast.datetime.toISOString()}
+				{...{
+					forecast,
+					gradientRange: calcGradientRange,
+					minTemp,
+					maxTemp,
+					currentTemp,
+					hourly,
+				}}
+			/>
+		) : (
+			<Day key={`forecast-placeholder-${String(index)}`} aria-hidden>
+				<SmallTemp>&nbsp;</SmallTemp>
+				<SmallIconSpacer />
+				<SmallTemp>&nbsp;</SmallTemp>
+				<TempBarSpacer />
+				<SmallTemp>&nbsp;</SmallTemp>
+			</Day>
+		),
+	);
 }
 
 const gradientMap: Map<number, Rgb> = new Map<number, Rgb>()
@@ -125,6 +138,15 @@ const SmallIcon = styled.img`
 	width: 10vh;
 	height: 10vh;
 `;
+const SmallIconSpacer = styled.span`
+	width: 10vh;
+	height: 10vh;
+	flex-shrink: 0;
+`;
+const TempBarSpacer = styled.span`
+	width: 100%;
+	height: var(--bar-height);
+`;
 
 const SmallTemp = styled.span`
 	font-size: 10vh;
@@ -162,8 +184,8 @@ function TemperatureBar({
 			<TempBarRange
 				{...{
 					moveRight,
-					startPercent: `${startPercent}%`,
-					endPercent: `${endPercent}%`,
+					startPercent: `${String(startPercent)}%`,
+					endPercent: `${String(endPercent)}%`,
 					gradient: gradient(gradientRange, startPercent, endPercent),
 				}}
 			>
@@ -220,7 +242,7 @@ function ForecastCurrentTemp({
 	const moveRight =
 		maxTempDay === minTempDay ? 0 : (currentTemp - minTempDay) / steps;
 	return (
-		<CurrentIndicator position={`${indicatorPosition}%`}>
+		<CurrentIndicator position={`${String(indicatorPosition)}%`}>
 			<CurrentIndicatorDot moveRight={moveRight} />
 		</CurrentIndicator>
 	);


### PR DESCRIPTION
## Summary
- Bump `packageManager` to pnpm 11.13.0 and add `pnpm-workspace.yaml` `allowBuilds` for esbuild/protobufjs
- Remove `.npmrc` `auto-install-peers` (not read by pnpm 11; default remains `true`)
- Pad short daily forecasts with placeholder rows so the weather card always keeps three slots

## Test plan
- [ ] Run `corepack prepare pnpm@11.13.0 --activate && pnpm install`
- [ ] Confirm install succeeds without a local `.npmrc`
- [ ] `pnpm build` completes
- [ ] Weather card shows three forecast rows even when fewer days are available
- [ ] Placeholder rows reserve layout without showing fake temperatures/icons


Made with [Cursor](https://cursor.com)